### PR TITLE
Add Orion to Rust implementations

### DIFF
--- a/draft-connolly-cfrg-xwing-kem.md
+++ b/draft-connolly-cfrg-xwing-kem.md
@@ -704,6 +704,7 @@ Description of "id-mod-XWing-kem-2024".
     Note: implements the older `-00` version of this memo at the time of
     writing.
 
+  - [Orion](https://github.com/orion-rs/orion)
 
 # Machine-readable specification {#S-spec}
 


### PR DESCRIPTION
We [recently](https://github.com/orion-rs/orion/pull/437) added support for X-Wing in Orion (disclaimer: I'm the author/maintainer), so I thought I'd add it to the list.

Let me know if you need me to do anything for the CI, but the fail seems unrelated to this change.